### PR TITLE
Use Object.defineProperty

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 *.un~
 /node_modules/*
+
+# Vim swap files
+.*.sw[a-z]

--- a/lib/delayed_stream.js
+++ b/lib/delayed_stream.js
@@ -38,8 +38,12 @@ DelayedStream.create = function(source, options) {
   return delayedStream;
 };
 
-DelayedStream.prototype.__defineGetter__('readable', function() {
-  return this.source.readable;
+Object.defineProperty(DelayedStream.prototype, 'readable', {
+  configurable: true,
+  enumerable: true,
+  get: function() {
+    return this.source.readable;
+  }
 });
 
 DelayedStream.prototype.setEncoding = function() {


### PR DESCRIPTION
This implements the `readable` property via `Object.defineProperty` instead of `__defineGetter__` since that has been deprecated. Note that this affects those who use this module in the browser because versions of IE before 11 do not support this and ES5 shim doesn't support this either since it is nonstandard and deprecated.